### PR TITLE
modified collect, WOT, audit, node commands to support govcloud regio…

### DIFF
--- a/commands/collect.py
+++ b/commands/collect.py
@@ -322,7 +322,7 @@ def collect(arguments):
                 if region["RegionName"] != default_region:
                     continue
             elif region["RegionName"] not in session.get_available_regions(
-                runner["Service"]
+                runner["Service"], partition_name='aws-us-gov' if 'gov-' in os.getenv('AWS_DEFAULT_REGION') else 'aws'
             ):
                 print(
                     "  Skipping region {}, as {} does not exist there".format(

--- a/commands/weboftrust.py
+++ b/commands/weboftrust.py
@@ -203,7 +203,11 @@ def get_iam_trusts(account, nodes, connections, connections_to_get):
 
                         if 'saml-provider/okta' in saml_provider_arn.lower():
                             node = Account(
-                                json_blob={"id": "okta", "name": "okta", "type": "Okta"}
+                                json_blob={
+                                    "id": "okta",
+                                    "name": "okta", 
+                                    "type": "Okta"
+                                }
                             )
                             assume_role_nodes.add(node)
                         elif "saml-provider/onelogin" in saml_provider_arn.lower():
@@ -233,14 +237,31 @@ def get_iam_trusts(account, nodes, connections, connections_to_get):
                                 }
                             )
                             assume_role_nodes.add(node)
+                        elif "saml-provider/awssso" in saml_provider_arn.lower():
+                            node = Account(
+                                json_blob={
+                                    "id": "AWSSSO",
+                                    "name": "AWS SSO",
+                                    "type": "Amazon",
+                                }
+                            )
+                            assume_role_nodes.add(node)
                         elif "saml-provider/adfs" in saml_provider_arn.lower():
                             node = Account(
-                                json_blob={"id": "adfs", "name": "adfs", "type": "ADFS"}
+                                json_blob={
+                                    "id": "adfs", 
+                                    "name": "adfs", 
+                                    "type": "ADFS"
+                                }
                             )
                             assume_role_nodes.add(node)
                         elif "saml-provider/auth0" in saml_provider_arn.lower():
                             node = Account(
-                                json_blob={"id": "auth0", "name": "auth0", "type": "auth0"}
+                                json_blob={
+                                    "id": "auth0", 
+                                    "name": "auth0", 
+                                    "type": "auth0"
+                                }
                             )
                             assume_role_nodes.add(node)
                         elif "saml-provider/google" in saml_provider_arn.lower():
@@ -269,6 +290,15 @@ def get_iam_trusts(account, nodes, connections, connections_to_get):
                                     "id": "Amazon.com",
                                     "name": "Amazon.com",
                                     "type": "Amazon",
+                                }
+                            )
+                            continue
+                        elif "lucidcharts" in saml_provider_arn.lower():
+                            node = Account(
+                                json_blob={
+                                    "id": "Lucidcharts",
+                                    "name": "Lucidcharts",
+                                    "type": "Lucidcharts",
                                 }
                             )
                             continue
@@ -420,6 +450,10 @@ def weboftrust(args, accounts, config):
         # Check if the account data exists
         if not path.exists(
             "./account-data/{}/us-east-1/iam-get-account-authorization-details.json".format(
+                account["name"]
+            )
+        ) or not path.exists(
+            "./account-data/{}/us-gov-west-1/iam-get-account-authorization-details.json".format(
                 account["name"]
             )
         ):

--- a/shared/audit.py
+++ b/shared/audit.py
@@ -1172,7 +1172,7 @@ def audit(accounts):
             region = Region(account, region_json)
 
             try:
-                if region.name == "us-east-1":
+                if region.name in ["us-east-1", "us-gov-west-1"]:
                     audit_s3_buckets(findings, region)
                     audit_cloudtrail(findings, region)
                     audit_iam(findings, region)

--- a/shared/common.py
+++ b/shared/common.py
@@ -328,10 +328,10 @@ def get_account_stats(account, all_resources=False):
 def get_us_east_1(account):
     for region_json in get_regions(account):
         region = Region(account, region_json)
-        if region.name == "us-east-1":
+        if region.name in ["us-east-1", "us-gov-west-1"]:
             return region
 
-    raise Exception("us-east-1 not found")
+    raise Exception("us-east-1 or us-gov-west-1 not found")
 
 
 def iso_date(d):

--- a/shared/iam_audit.py
+++ b/shared/iam_audit.py
@@ -179,7 +179,7 @@ def find_admins_in_account(
 
     try:
         file_name = "account-data/{}/{}/{}".format(
-            account.name, "us-east-1", "iam-get-account-authorization-details.json"
+            account.name, "us-gov-west-1" if account.partition == "aws-us-gov" else 'us-east-1', "iam-get-account-authorization-details.json"
         )
         iam = json.load(open(file_name))
     except:


### PR DESCRIPTION
…ns when the AWS_REGION is set to a govcloud region.

Where necessary, logic has been added to determine the partition in which resources are found. `aws` is fine for commercial accounts, but `aws-gov-us` is used for govcloud accounts in the US. Additionally, `us-gov-west-1` is the 'global' region for govcloud - checks that force `us-east-1` checks will instead choose `us-gov-west-1` if the default region is a govcloud region.